### PR TITLE
Add keyword to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "CC0-1.0"
 description = "Prime factorization up to 128 bit integers."
 
-keywords = ["prime-factorization", "modular-arithmetic", "elliptic-curves"]
+keywords = ["prime-factorization", "modular-arithmetic", "elliptic-curves", "factorization"]
 categories = ["mathematics"]
 repository = "https://github.com/elmomoilanen/prime-factorization"
 readme = "README.md"


### PR DESCRIPTION
Please, consider adding "factorization" tag to the list. Of course, it duplicates "prime-factorization" which is better, but search engines tend to return <https://crates.io/keywords/factorization>, and it would be nice to see your crate there!